### PR TITLE
[Feat] 세금 계산서 조회 API 추가 구현 및 수정

### DIFF
--- a/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/controller/NtsTaxController.java
+++ b/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/controller/NtsTaxController.java
@@ -5,7 +5,7 @@ import com.seoulmilk.seoulmilkServer.domain.agency.service.AgencyAuthService;
 import com.seoulmilk.seoulmilkServer.domain.member.domain.Member;
 import com.seoulmilk.seoulmilkServer.domain.member.service.MemberAuthService;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.NtsTax;
-import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.Status;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.IsSuccess;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.request.DeleteNtsTaxRequestDTO;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.request.SubmitNtxTaxRequestDTO;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.request.UpdateNtsTaxRequestDTO;
@@ -13,7 +13,6 @@ import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.GetHometaxRespon
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.GetNtsTaxListResponseDTO;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.GetOcrNtsTaxListResponseDTO;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.UpdateNtsTaxResponseDTO;
-import com.seoulmilk.seoulmilkServer.domain.ntsTax.service.HomeTaxService;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.service.NtsTaxCommandService;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.service.NtsTaxQueryService;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.service.NtxTaxMappingService;
@@ -80,17 +79,16 @@ public class NtsTaxController {
     @Operation(summary = "세금 계산서 목록 조회")
     @GetMapping("/nts-tax")
     public ApiResponse<GetNtsTaxListResponseDTO.NtsTaxListResponseDTO> getNtsTaxList(
-        @RequestParam(name = "page") Integer page) {
+            @RequestParam(name = "page") Integer page,
+            @RequestParam(name = "isSuccess") IsSuccess isSuccess) {
         Agency agency = agencyAuthService.getCurrentAgency();
 
-        Page<NtsTax> ntsTaxList = ntsTaxQueryService.getNtsTaxList(agency, page);
-
-        return ApiResponse.success(GetNtsTaxListResponseDTO.from(ntsTaxList));
+        return ApiResponse.success(ntsTaxQueryService.getNtsTaxList(agency, page, isSuccess));
     }
 
-    @Operation(summary = "세금 계산서 통합 조회 - 조건 설정 후 탐색")
+    @Operation(summary = "세금 계산서 통합 조회 - 조건 설정 후 검색")
     @GetMapping("/nts-tax/search")
-    public ApiResponse<GetNtsTaxListResponseDTO.NtsTaxListResponseDTO> searchNtsTaxList(
+    public ApiResponse<GetNtsTaxListResponseDTO.SearchNtsTaxListResponseDTO> searchNtsTaxList(
         @RequestParam(name = "page") Integer page,
         @RequestParam(required = false) LocalDate startDate,
         @RequestParam(required = false) LocalDate endDate,

--- a/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/dto/response/GetNtsTaxListResponseDTO.java
+++ b/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/dto/response/GetNtsTaxListResponseDTO.java
@@ -71,11 +71,23 @@ public class GetNtsTaxListResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class NtsTaxListResponseDTO {
+    public static class SearchNtsTaxListResponseDTO {
         List<GetNtsTaxListResponseDTO> ntsTaxList;
         Integer listSize;
         Integer totalPage;
         Long totalElements;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NtsTaxListResponseDTO {
+        List<GetNtsTaxListResponseDTO> ntsTaxList;
+        Integer listSize;
+        Integer totalPage;
+        Long successElements;
+        Long failedElements;
     }
 
     public static GetNtsTaxListResponseDTO from(NtsTax ntsTax) {
@@ -98,11 +110,25 @@ public class GetNtsTaxListResponseDTO {
                 .build();
     }
 
-    public static NtsTaxListResponseDTO from(Page<NtsTax> ntsTaxList) {
+    public static NtsTaxListResponseDTO of(Page<NtsTax> ntsTaxList, Long successCnt, Long failedCnt) {
+        List<GetNtsTaxListResponseDTO> getNtsTaxList = ntsTaxList.stream()
+                .map(GetNtsTaxListResponseDTO::from)
+                .collect(Collectors.toList());
+
+        return NtsTaxListResponseDTO.builder()
+                .ntsTaxList(getNtsTaxList)
+                .listSize(getNtsTaxList.size())
+                .totalPage(ntsTaxList.getTotalPages())
+                .successElements(successCnt)
+                .failedElements(failedCnt)
+                .build();
+    }
+
+    public static SearchNtsTaxListResponseDTO from(Page<NtsTax> ntsTaxList) {
         List<GetNtsTaxListResponseDTO> getNtsTaxList = ntsTaxList.stream()
                 .map(GetNtsTaxListResponseDTO::from).collect(Collectors.toList());
 
-        return NtsTaxListResponseDTO.builder()
+        return SearchNtsTaxListResponseDTO.builder()
                 .ntsTaxList(getNtsTaxList)
                 .listSize(getNtsTaxList.size())
                 .totalPage(ntsTaxList.getTotalPages())

--- a/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/repository/NtsTaxRepository.java
+++ b/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/repository/NtsTaxRepository.java
@@ -2,6 +2,7 @@ package com.seoulmilk.seoulmilkServer.domain.ntsTax.repository;
 
 import com.seoulmilk.seoulmilkServer.domain.member.domain.Member;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.NtsTax;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.IsSuccess;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,11 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 
 public interface NtsTaxRepository extends JpaRepository<NtsTax, Long>, NtsTaxRepositoryCustom {
+    // 세금 계산서 목록 조회
+    Page<NtsTax> findByAgencyIdAndIsSuccess(Long agencyId, IsSuccess isSuccess, Pageable pageable);
+    Long countByIsSuccess(IsSuccess isSuccess);
+
+    // 세금 계산서 진위 여부 검증 후, 검색
     @Query("SELECT n FROM NtsTax n " +
             "WHERE n.member = :member " +
             "AND n.createdAt BETWEEN :startDateTime AND :endDateTime " +

--- a/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/service/NtsTaxQueryService.java
+++ b/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/service/NtsTaxQueryService.java
@@ -3,15 +3,17 @@ package com.seoulmilk.seoulmilkServer.domain.ntsTax.service;
 import com.seoulmilk.seoulmilkServer.domain.agency.domain.Agency;
 import com.seoulmilk.seoulmilkServer.domain.member.domain.Member;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.NtsTax;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.IsSuccess;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.Status;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.GetNtsTaxListResponseDTO;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface NtsTaxQueryService {
-    Page<NtsTax> getNtsTaxList(Agency agency, Integer page); // 세금 계산서 목록 조회
+    GetNtsTaxListResponseDTO.NtsTaxListResponseDTO getNtsTaxList(Agency agency, Integer page, IsSuccess isSuccess); // 세금 계산서 목록 조회
     Page<NtsTax> searchNtsTaxList(Agency agency, Integer page, LocalDate startDate, LocalDate endDate, List<String> ipNameList); // 세금 계산서 통합 조회 - 조건 기준 탐색
-    // 세금 계산서 진위 여부 검증 후, 상태 및 월별 조회
+    // 세금 계산서 진위 여부 검증 후, 상태 및 월 별 조회
     Page<NtsTax> searchHometaxList(Member member, Integer page, LocalDate startMonth, LocalDate endMonth, String suName, String ipName); // 세금 계산서 진위 여부 검증 후, 검색
 }

--- a/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/service/NtsTaxQueryServiceImpl.java
+++ b/src/main/java/com/seoulmilk/seoulmilkServer/domain/ntsTax/service/NtsTaxQueryServiceImpl.java
@@ -3,13 +3,15 @@ package com.seoulmilk.seoulmilkServer.domain.ntsTax.service;
 import com.seoulmilk.seoulmilkServer.domain.agency.domain.Agency;
 import com.seoulmilk.seoulmilkServer.domain.member.domain.Member;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.NtsTax;
-import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.Status;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.domain.enums.IsSuccess;
+import com.seoulmilk.seoulmilkServer.domain.ntsTax.dto.response.GetNtsTaxListResponseDTO;
 import com.seoulmilk.seoulmilkServer.domain.ntsTax.repository.NtsTaxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,12 +28,16 @@ public class NtsTaxQueryServiceImpl implements NtsTaxQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<NtsTax> getNtsTaxList(Agency agency, Integer page) {
-        Pageable pageable = PageRequest.of(page, 13);
+    public GetNtsTaxListResponseDTO.NtsTaxListResponseDTO getNtsTaxList(Agency agency, Integer page, IsSuccess isSuccess) {
+        Pageable pageable = PageRequest.of(page, 13, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        Page<NtsTax> ntsTaxPage = ntsTaxRepository.findAll(pageable);
+        Page<NtsTax> ntsTaxPage = ntsTaxRepository.findByAgencyIdAndIsSuccess(agency.getId(), isSuccess, pageable);
 
-        return ntsTaxPage;
+        // 전체 성공, 실패 건 수 조회
+        Long successCnt = ntsTaxRepository.countByIsSuccess(IsSuccess.SUCCESS);
+        Long failedCnt = ntsTaxRepository.countByIsSuccess(IsSuccess.FAILED);
+
+        return GetNtsTaxListResponseDTO.of(ntsTaxPage, successCnt, failedCnt);
     }
 
     @Override


### PR DESCRIPTION
## PULL REQUEST

### 🛠️ 작업중인 브랜치

- #60

### 🔑 주요 변경사항

- 세금 계산서 목록 조회 시, 성공 / 실패 건 수 나눠서 조회
- 조회 respone에 성공 / 실패 건 수 추가

### 💡 관련 이슈

- #60